### PR TITLE
JBIDE-6313 important changes to pull esb away from deprecated wtp classes

### DIFF
--- a/plugins/org.jboss.tools.esb.project.core/src/org/jboss/tools/esb/core/facet/JBossESBFacetInstallationDelegate.java
+++ b/plugins/org.jboss.tools.esb.project.core/src/org/jboss/tools/esb/core/facet/JBossESBFacetInstallationDelegate.java
@@ -82,6 +82,12 @@ public class JBossESBFacetInstallationDelegate implements IDelegate {
 				IJBossESBFacetDataModelProperties.ESB_CONTENT_FOLDER);
 		jbiRoot.createLink(new Path("/" + resourcesFolder), 0, null);
 				
+		String sourcesFolder = model.getStringProperty(
+				IJBossESBFacetDataModelProperties.ESB_SOURCE_FOLDER);
+		jbiRoot.createLink(new Path("/" + sourcesFolder), 0, null);
+
+		
+		
 		//addESBNature(project);
 		IVirtualComponent outputFoldersComponent = new OutputFoldersVirtualComponent(project, newComponent);
 		VCFUtil.addReference(outputFoldersComponent, newComponent, "/", null);

--- a/plugins/org.jboss.tools.esb.project.core/src/org/jboss/tools/esb/core/module/JBossESBModuleDelegate.java
+++ b/plugins/org.jboss.tools.esb.project.core/src/org/jboss/tools/esb/core/module/JBossESBModuleDelegate.java
@@ -11,6 +11,7 @@
 package org.jboss.tools.esb.core.module;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.resources.IContainer;
@@ -24,20 +25,49 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jst.common.internal.modulecore.AddMappedOutputFoldersParticipant;
+import org.eclipse.jst.common.internal.modulecore.IgnoreJavaInSourceFolderParticipant;
+import org.eclipse.jst.j2ee.internal.classpathdep.ClasspathDependencyEnablement;
+import org.eclipse.jst.j2ee.internal.common.exportmodel.JEEHeirarchyExportParticipant;
+import org.eclipse.jst.j2ee.internal.deployables.JEEFlattenParticipantProvider;
 import org.eclipse.wst.common.componentcore.ComponentCore;
+import org.eclipse.wst.common.componentcore.internal.flat.FlattenParticipantModel;
+import org.eclipse.wst.common.componentcore.internal.flat.IFlattenParticipant;
 import org.eclipse.wst.common.componentcore.resources.IVirtualComponent;
 import org.eclipse.wst.common.componentcore.resources.IVirtualFolder;
 import org.eclipse.wst.server.core.model.IModuleResource;
 import org.jboss.ide.eclipse.as.wtp.core.modules.IJBTModule;
-import org.jboss.ide.eclipse.as.wtp.core.modules.JBTProjectModuleDelegate;
+import org.jboss.ide.eclipse.as.wtp.core.modules.JBTFlatModuleDelegate;
+import org.jboss.ide.eclipse.as.wtp.core.modules.JBTFlatProjectModuleFactory;
+import org.jboss.ide.eclipse.as.wtp.core.vcf.JBTHeirarchyParticipantProvider;
 import org.jboss.tools.esb.core.ESBProjectCorePlugin;
 import org.jboss.tools.esb.core.StatusUtils;
 import org.jboss.tools.esb.core.facet.IJBossESBFacetDataModelProperties;
 
-public class JBossESBModuleDelegate extends JBTProjectModuleDelegate implements IJBTModule {
+public class JBossESBModuleDelegate extends JBTFlatModuleDelegate implements IJBTModule {
 
-	public JBossESBModuleDelegate(IProject project){
-		super(project);
+	public JBossESBModuleDelegate(IProject project,
+			IVirtualComponent aComponent, JBTFlatProjectModuleFactory myFactory) {
+		super(project, aComponent, myFactory);
+	}
+	
+	public IFlattenParticipant[] getParticipants() {
+		String[] ids = getParticipantIds();
+		return getFlattenParticipants(ids);
+	}
+	
+	@Override
+	public String[] getDefaultFlattenParticipantIDs() {
+		String[] defaultParticipants = new String[]{
+				JEEFlattenParticipantProvider.JEESingleRootParticipant,
+				JEEFlattenParticipantProvider.JEEHeirarchyExportParticipant,
+				JEEFlattenParticipantProvider.AddClasspathLibReferencesParticipant,
+				JEEFlattenParticipantProvider.AddClasspathFoldersParticipant,
+				JEEFlattenParticipantProvider.AddMappedOutputFoldersParticipant,
+				JEEFlattenParticipantProvider.IgnoreJavaInSourceFolderParticipant,
+				JEEFlattenParticipantProvider.FilterResourceParticipant
+		};
+		return defaultParticipants;
 	}
 
 	public IModuleResource[] members() throws CoreException {
@@ -86,10 +116,5 @@ public class JBossESBModuleDelegate extends JBTProjectModuleDelegate implements 
 			System.arraycopy(mr, 0, allResource, esbContent.length + classes.length, mr.length);
 		}
 		return allResource;
-	}
-
-	@Override
-	protected String getFactoryId() {
-		return JBossESBModuleFactory.FACTORY_ID;
 	}
 }

--- a/plugins/org.jboss.tools.esb.project.core/src/org/jboss/tools/esb/core/module/JBossESBModuleFactory.java
+++ b/plugins/org.jboss.tools.esb.project.core/src/org/jboss/tools/esb/core/module/JBossESBModuleFactory.java
@@ -10,13 +10,20 @@
  ******************************************************************************/
 package org.jboss.tools.esb.core.module;
 
+import java.io.File;
+
 import org.eclipse.core.resources.IProject;
+import org.eclipse.wst.common.componentcore.internal.flat.IChildModuleReference;
+import org.eclipse.wst.common.componentcore.resources.IVirtualComponent;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.web.internal.deployables.FlatComponentDeployable;
+import org.jboss.ide.eclipse.as.wtp.core.modules.JBTFlatProjectModuleFactory;
 import org.jboss.ide.eclipse.as.wtp.core.modules.JBTProjectModuleDelegate;
 import org.jboss.ide.eclipse.as.wtp.core.modules.JBTProjectModuleFactory;
 import org.jboss.tools.esb.core.ESBProjectConstant;
 import org.jboss.tools.esb.core.facet.IJBossESBFacetDataModelProperties;
 
-public class JBossESBModuleFactory extends JBTProjectModuleFactory {
+public class JBossESBModuleFactory extends JBTFlatProjectModuleFactory {
 	public static final String FACTORY_ID = "org.jboss.tools.esb.project.core.moduleFactory";
 	public static final String MODULE_TYPE = IJBossESBFacetDataModelProperties.JBOSS_ESB_FACET_ID;
 
@@ -25,11 +32,43 @@ public class JBossESBModuleFactory extends JBTProjectModuleFactory {
 	}
 	
 	public JBossESBModuleFactory() {
-		super(MODULE_TYPE, ESBProjectConstant.ESB_PROJECT_FACET);
+		super();
 	}
 
-	protected JBTProjectModuleDelegate createDelegate(IProject project) {
-		return new JBossESBModuleDelegate(project);
+	protected FlatComponentDeployable createModuleDelegate(IProject project, IVirtualComponent component) {
+		return new JBossESBModuleDelegate(project, component, this);
+	}
+	
+	protected boolean canHandleProject(IProject p) {
+		return hasProjectFacet(p, MODULE_TYPE);
+	}
+	
+	@Override
+	protected String getModuleType(IProject project) {
+		return MODULE_TYPE;
+	}
+
+	@Override
+	protected String getModuleVersion(IProject project) {
+		return getFacetVersion(project, MODULE_TYPE);
+	}
+
+	@Override
+	protected String getModuleType(File binaryFile) {
+		// esb allows no child modules
+		return null;
+	}
+
+	@Override
+	protected String getModuleVersion(File binaryFile) {
+		// esb allows no child modules
+		return null;
+	}
+
+	@Override 
+	public IModule createChildModule(FlatComponentDeployable parent, IChildModuleReference child) {
+		// esb allows no child modules
+		return null;
 	}
 
 }

--- a/plugins/org.jboss.tools.esb.project.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.esb.project.ui/META-INF/MANIFEST.MF
@@ -37,8 +37,8 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.ide.eclipse.as.wtp.core;bundle-version="1.0.0",
  org.jboss.ide.eclipse.as.core;bundle-version="1.0.0",
  org.jboss.tools.common.ui;bundle-version="3.1.0",
- org.eclipse.zest.core,
- org.eclipse.zest.layouts
+ org.eclipse.zest.core;resolution:=optional,
+ org.eclipse.zest.layouts;resolution:=optional
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor.0
 Eclipse-RegisterBuddy: org.eclipse.jst.ws.annotations.core

--- a/plugins/org.jboss.tools.esb.project.ui/src/org/jboss/tools/esb/project/ui/wizards/export/ESBComponentExportDataModelProvider.java
+++ b/plugins/org.jboss.tools.esb.project.ui/src/org/jboss/tools/esb/project/ui/wizards/export/ESBComponentExportDataModelProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jst.j2ee.application.internal.operations.J2EEComponentExportDataModelProvider;
+import org.eclipse.jst.j2ee.internal.archive.operations.JavaEEComponentExportOperation;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.wst.common.componentcore.internal.util.ComponentUtilities;
 import org.eclipse.wst.common.componentcore.resources.IVirtualComponent;
@@ -33,7 +34,7 @@ public class ESBComponentExportDataModelProvider extends
 		J2EEComponentExportDataModelProvider {
 
 	public IDataModelOperation getDefaultOperation() {
-		return new ESBComponentExportOperation(model);
+		return new JavaEEComponentExportOperation(model);
 	}
 
 	public Set getPropertyNames() {

--- a/plugins/org.jboss.tools.esb.project.ui/src/org/jboss/tools/esb/project/ui/wizards/export/ESBComponentExportOperation.java
+++ b/plugins/org.jboss.tools.esb.project.ui/src/org/jboss/tools/esb/project/ui/wizards/export/ESBComponentExportOperation.java
@@ -14,6 +14,10 @@ import org.eclipse.wst.common.frameworks.datamodel.IDataModel;
 import org.jboss.ide.eclipse.as.wtp.core.vcf.ModuleExportOperation;
 import org.jboss.tools.esb.core.ESBProjectConstant;
 
+/**
+ * Candidate for removal
+ */
+@Deprecated
 public class ESBComponentExportOperation extends ModuleExportOperation {
 	public ESBComponentExportOperation() {
 		super();

--- a/plugins/org.jboss.tools.esb.project.ui/src/org/jboss/tools/esb/project/ui/wizards/export/ESBComponentExportPage.java
+++ b/plugins/org.jboss.tools.esb.project.ui/src/org/jboss/tools/esb/project/ui/wizards/export/ESBComponentExportPage.java
@@ -11,7 +11,12 @@
 package org.jboss.tools.esb.project.ui.wizards.export;
 
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jst.j2ee.datamodel.properties.IJ2EEComponentExportDataModelProperties;
+import org.eclipse.jst.j2ee.internal.plugin.J2EEUIMessages;
 import org.eclipse.jst.j2ee.internal.wizard.J2EEModuleExportPage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.wst.common.frameworks.datamodel.IDataModel;
 import org.jboss.tools.esb.project.ui.ESBSharedImages;
 import org.jboss.tools.esb.project.ui.messages.JBossESBUIMessages;
@@ -54,5 +59,4 @@ public class ESBComponentExportPage extends J2EEModuleExportPage {
 	protected String getCompnentID() {
 		return "JST_JBOSS_ESB"; //$NON-NLS-1$
 	}
-
 }


### PR DESCRIPTION
The attached patch makes esb align very closely with the much better organized wtp code. The upstream finally works very well, and the old classes are deprecated, so its 100% time to move away. 
